### PR TITLE
fixing bug while moving board down

### DIFF
--- a/logic.py
+++ b/logic.py
@@ -148,7 +148,7 @@ def moveDown(board):
         board (list): updated game board
     """
     board = rotateLeft(board)
-    board = moveLeft(board)
+    board = moveRight(board)
     shiftRight(board)
     board = rotateRight(board)
     return board


### PR DESCRIPTION
Hi,

I have fixed a bug which can happen when three or more tiles are in the same column and you want to merge them down. The issue was that only the upper ones were merged and not the bottom ones. Now, such a top-down merge behaves the same as a left or right merge.

Regards, 
Thomas